### PR TITLE
jade fix

### DIFF
--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
     var data = this.data.data;
 
     file.expand(files).forEach(function (filename) {
-      var opts = _.extend(options, {filename: filename});
+      var opts = _.extend({filename: filename}, options);
       var html = grunt.helper("jade", file.read(filename), opts, data);
 
       var basename = path.basename(filename);

--- a/test/fixtures/jade/inc/head.jade
+++ b/test/fixtures/jade/inc/head.jade
@@ -1,0 +1,4 @@
+html
+  head
+    title TEST
+  body

--- a/test/fixtures/jade/jadeInclude.jade
+++ b/test/fixtures/jade/jadeInclude.jade
@@ -1,0 +1,4 @@
+include inc/head.jade
+
+- var a = 'hello jade test'
+p= a

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -16,12 +16,16 @@ module.exports = function(grunt) {
     },
 
     jade: {
-      compile: {
+      simple: {
         src: "fixtures/jade/jade.jade",
         dest: "fixtures/output",
         data: {
           test: true
         }
+      },
+      include: {
+        src: "fixtures/jade/jadeInclude.jade",
+        dest: "fixtures/output"
       }
     },
 
@@ -53,7 +57,14 @@ module.exports = function(grunt) {
           compress: true
         }
       }
+    },
+    
+    options: {
+      jade: {
+        filename: 'fixtures/jade/inc/'
+      }
     }
+    
 
   });
 

--- a/test/jade_test.js
+++ b/test/jade_test.js
@@ -7,10 +7,15 @@ exports.jade = {
   },
 
   helper: function(test) {
-     var expect = '<div id="test" class="test"><span id="data">data</span><div>testing</div></div>';
-     var result = grunt.file.read("test/fixtures/output/jade.html");
+    
+     var expectSimple = '<div id="test" class="test"><span id="data">data</span><div>testing</div></div>'
+       , resultSimple = grunt.file.read("test/fixtures/output/jade.html")
+       , expectInclude = '<html><head><title>TEST</title></head><body></body></html><p>hello jade test</p>'
+       , resultInclude = grunt.file.read("test/fixtures/output/jadeInclude.html")
 
-     test.equal(expect, result, "should compile jade templates to html");
+     test.expect(2);
+     test.equal(expectSimple, resultSimple, "should compile jade templates to html");
+     test.equal(expectInclude, resultInclude, "should compile jade templates to html with an include");
      test.done();
   }
 


### PR DESCRIPTION
The [jade API](https://github.com/visionmedia/jade#a5) uses 'filename' option to refer to 'Used in exceptions, and required when using includes'. Trying to do includes was not working because of the line 27:

```
var opts = _.extend(options, {filename: filename});
```

Deleting this line produces the desired results so the `grunt.js` file figure out how to compile in includes using something like this:

```
options: {
  jade: {
    filename: 'source/includes/'
  }
}
```
