### PR TITLE
Allow data to be passed to the jade template when rendered

### DIFF
--- a/docs/jade.md
+++ b/docs/jade.md
@@ -23,3 +23,23 @@ options: {
   }
 },
 ```
+
+Set the data passed to the compiled jade template when it is rendered in a
+property named `data` on the target. Any data can be passed to the template.
+This can be used to generate a debug file and a release file from the same
+template, by using this:
+
+``` javascript
+jade: {
+  debug: {
+    src: "test.jade",
+    dest: "debug/",
+    data: { debug: true }
+  },
+  release: {
+    src: "test.jade",
+    dest: "release/",
+    data: { debug: true }
+  }
+}
+```

--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -3,7 +3,7 @@
  * Task: jade
  * Description: Compile Jade templates to HTML
  * Dependencies: jade, path
- * Contributor(s): @errcw
+ * Contributor(s): @errcw / @conradz
  *
  */
 
@@ -19,13 +19,16 @@ module.exports = function(grunt) {
     "Compile Jade templates into HTML.", function() {
     var path = require("path");
 
-    var files = this.data;
-    var dest = this.target;
+    var files = this.file.src;
+    var dest = this.file.dest;
     var options = config("options.jade") || {};
+    // Data is specified per target so the same template
+    // can generate multiple outputs depending on the data
+    var data = this.data.data;
 
     file.expand(files).forEach(function (filename) {
       var opts = _.extend(options, {filename: filename});
-      var html = grunt.helper("jade", file.read(filename), opts);
+      var html = grunt.helper("jade", file.read(filename), opts, data);
 
       var basename = path.basename(filename);
       var extname = path.extname(filename);
@@ -37,10 +40,10 @@ module.exports = function(grunt) {
     });
   });
 
-  grunt.registerHelper("jade", function(src, options) {
+  grunt.registerHelper("jade", function(src, options, data) {
     var jade = require("jade");
     var jadeFn = jade.compile(src, options);
-    return jadeFn();
+    return jadeFn(data);
   });
 
 };

--- a/test/fixtures/jade/jade.jade
+++ b/test/fixtures/jade/jade.jade
@@ -1,2 +1,4 @@
 #test.test
   span#data data
+  if test
+    div testing

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -16,7 +16,13 @@ module.exports = function(grunt) {
     },
 
     jade: {
-      "fixtures/output": "fixtures/jade/jade.jade"
+      compile: {
+        src: "fixtures/jade/jade.jade",
+        dest: "fixtures/output",
+        data: {
+          test: true
+        }
+      }
     },
 
     less: {

--- a/test/jade_test.js
+++ b/test/jade_test.js
@@ -7,9 +7,9 @@ exports.jade = {
   },
 
   helper: function(test) {
-     var expect = '<div id="test" class="test"><span id="data">data</span></div>';
+     var expect = '<div id="test" class="test"><span id="data">data</span><div>testing</div></div>';
      var result = grunt.file.read("test/fixtures/output/jade.html");
- 
+
      test.equal(expect, result, "should compile jade templates to html");
      test.done();
   }


### PR DESCRIPTION
This change allows data to be specified per target that will be passed to the jade template when it is rendered to an html file. This can be used for generating a debug and a release file from the same template, depending on the data that is specified for the target.
