### PR TITLE
module dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
     "grunt": "~0.3.8",
     "rimraf": "1.0.9",
     "clean-css": "0.3.2",
-    "requirejs": "1.0.7",
-    "express": "2.5.4",
     "less": "1.3.0",
     "stylus": "0.26.0",
     "coffee-script": "1.3.1",


### PR DESCRIPTION
I dont see where express and requirejs are required dependencies. tests pass without them, so either they arent needed and can be removed, or the tests are not testing everything.
