### PR TITLE
Option Test Patch

### DIFF
--- a/test/grunt.js
+++ b/test/grunt.js
@@ -83,22 +83,6 @@ module.exports = function(grunt) {
     options: {
       jade: {
         filename: 'fixtures/jade/inc/'
-      },
-      task: {
-        param: 'default',
-        setting: 'set',
-        global: 'set',
-        subtask: {
-          setting: 'subtask'
-        }
-      }
-    },
-
-    task: {
-      subtask: {
-        options: {
-          param: 'override all'
-        }
       }
     }
   });

--- a/test/options_test.js
+++ b/test/options_test.js
@@ -1,8 +1,31 @@
 var grunt = require("grunt");
 
+grunt.initConfig({
+  options: {
+    task: {
+      param: 'default',
+      setting: 'set',
+      global: 'set',
+      subtask: {
+        setting: 'subtask'
+      }
+    }
+  },
+
+  task: {
+    subtask: {
+      options: {
+        param: 'override all'
+      }
+    }
+  }
+});
+
+grunt.loadTasks("../tasks");
+
 exports.options = {
   main: function(test) {
-    var options = grunt.helper("options", { nameArgs: 'task:subtask' });
+    var options = grunt.helper("options", {nameArgs: 'task:subtask'});
 
     test.expect(3);
     test.equal('set', options.global, "should get params from global options.task key");


### PR DESCRIPTION
This should fix the option test bug introduced by #25. It boils down to you have to completely reload the tasks within nodeunit tests. For some reason, `npm test` isn't effected but `grunt test` is, maybe due to scope?
