### PR TITLE
Ensure fixtures/output dir exists before running tests

### DIFF
--- a/test/grunt.js
+++ b/test/grunt.js
@@ -1,4 +1,7 @@
 module.exports = function(grunt) {
+
+  grunt.file.mkdir('fixtures/output');
+
   grunt.initConfig({
     pkg: {
       name: "grunt-contrib",


### PR DESCRIPTION
On a fresh clone if you run `npm test`, clean dies with `<FATAL> should have an array of valid paths to clean by now, too dangerous to continue. </FATAL>` because the `fixtures/output` folder doesn't exist.
