### PR TITLE
support for partials where templates resides in a folder structure

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -34,7 +34,7 @@ module.exports = function(grunt) {
       var templateFunction =
         require("handlebars").precompile(grunt.file.read(filepath));
 
-      return namespace + "['" + filepath + "'] = " + templateFunction;
+      return namespace + "['" + fileName.substring(0, fileName.indexOf('.')) + "'] = " + templateFunction;
     }).join("\n\n") : "";
 
     return contents;


### PR DESCRIPTION
if out of the name of template, the full filepath is generated as precompiled handlebars template, e.g. usage of partials will not work, because handlebars.js npm will render filename as a reference, instead of full path
