### PR TITLE
jst

### DIFF
--- a/docs/jst.md
+++ b/docs/jst.md
@@ -27,6 +27,19 @@ This controls how this task (and its helpers) operate and should contain key:val
 
 The namespace in which the resulting JST templates are assigned to.
 
+##### processName ```function```
+
+This option accepts a function that adjusts the template filepath.
+
+``` javascript
+options: {
+  processName: function(filepath) {
+    // shorten the filepath
+    return filepath.split('fixtures/').pop();
+  }
+}
+```
+
 ##### templateSettings ```object```
 
 The settings passed to underscore when compiling templates.

--- a/tasks/jst.js
+++ b/tasks/jst.js
@@ -47,6 +47,11 @@ module.exports = function(grunt) {
   });
 
   grunt.registerHelper("jst", function(source, filepath, namespace, options) {
+
+    if (typeof options.processName == "function") {
+      filepath = options.processName(filepath);
+    }
+
     try {
       if (options.underscore === true) {
         return namespace + "['" + filepath + "'] = _.template(" + JSON.stringify(source) + ");";

--- a/test/grunt.js
+++ b/test/grunt.js
@@ -210,6 +210,16 @@ module.exports = function(grunt) {
         options: {
           underscore: true
         }
+      },
+      compileC: {
+        files: {
+          "fixtures/output/jst_c.js": "fixtures/jst/*.html"
+        },
+        options: {
+          processName: function(filepath) {
+            return filepath.split('fixtures/').pop();
+          }
+        }
       }
     },
 

--- a/test/jst_test.js
+++ b/test/jst_test.js
@@ -2,7 +2,7 @@ var grunt = require("grunt");
 
 exports.jst = {
   main: function(test) {
-    test.expect(2);
+    test.expect(3);
 
     var expectA = "this['JST'] = this['JST'] || {};\n\nthis['JST']['fixtures/jst/template.html'] = function(obj){\nvar __p='';var print=function(){__p+=Array.prototype.join.call(arguments, '')};\nwith(obj||{}){\n__p+='<head><title>'+\n( title )+\n'</title></head>';\n}\nreturn __p;\n};";
     var resultA = grunt.file.read("fixtures/output/jst_a.js");
@@ -10,7 +10,11 @@ exports.jst = {
 
     var expectB = "this['JST'] = this['JST'] || {};\n\nthis['JST']['fixtures/jst/template.html'] = _.template(\"<head><title><%= title %></title></head>\");"
     var resultB = grunt.file.read("fixtures/output/jst_b.js");
-    test.equal(expectB, resultB, "should compile underscore templates into JST");
+    test.equal(expectB, resultB, "should compile underscore templates into JST, using `_.template`");
+
+    var expectC = "this['JST'] = this['JST'] || {};\n\nthis['JST']['jst/template.html'] = function(obj){\nvar __p='';var print=function(){__p+=Array.prototype.join.call(arguments, '')};\nwith(obj||{}){\n__p+='<head><title>'+\n( title )+\n'</title></head>';\n}\nreturn __p;\n};";
+    var resultC = grunt.file.read("fixtures/output/jst_c.js");
+    test.equal(expectC, resultC, "should compile underscore templates into JST, with a modified filepath");
 
     test.done();
   }


### PR DESCRIPTION
by adding option `underscore: true` to `jst` task underscore template are created (`_.template(/* ... */)`) instead of anonymous functions.
