### PR TITLE
Allow less task to complete even when reaching an error

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -41,8 +41,12 @@ module.exports = function(grunt) {
         helperOptions = _.extend({filename: srcFile}, options);
         sourceCode = grunt.file.read(srcFile);
 
-        grunt.helper("less", sourceCode, helperOptions, function(css) {
-          nextConcat(null, css);
+        grunt.helper("less", sourceCode, helperOptions, function(css, err) {
+          if(!err){
+            nextConcat(null, css);
+          } else {
+            done();
+          }
         });
       }, function(err, css) {
         grunt.file.write(file.dest, css.join("\n") || "");
@@ -67,6 +71,7 @@ module.exports = function(grunt) {
         callback(css);
       } catch (e) {
         lessError(e);
+        callback(css, true);
       }
     });
   });


### PR DESCRIPTION
When using the less task in conjunction with the grunt watch task, when an error occurs in the less compilation, the watch task will not continue to watch files as `done();` is never reached in the less task.

Allowing the less task to complete even when an error has occurred means you don't have to restart grunt every time you have an error in your less files. 
