### PR TITLE
bump grunt-contrib-jasmine to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-contrib-htmlmin": "~0.1.1",
     "grunt-contrib-imagemin": "~0.1.2",
     "grunt-contrib-jade": "~0.5.0",
-    "grunt-contrib-jasmine": "~0.3.3",
+    "grunt-contrib-jasmine": "~0.4.1",
     "grunt-contrib-jshint": "~0.2.0",
     "grunt-contrib-jst": "~0.5.0",
     "grunt-contrib-less": "~0.5.0",


### PR DESCRIPTION
version 0.3.3 won't install for me anymore (node v.0.10.1), b/c old phantomjs dependency.
