### PR TITLE
Update grunt-contrib-compress

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-coffee": "~0.10.0",
     "grunt-contrib-compass": "~0.7.0",
-    "grunt-contrib-compress": "~0.7.0",
+    "grunt-contrib-compress": "~0.8.0",
     "grunt-contrib-concat": "~0.4.0",
     "grunt-contrib-connect": "~0.7.0",
     "grunt-contrib-copy": "~0.5.0",


### PR DESCRIPTION
```
error peerinvalid The package grunt-contrib-compress does not satisfy its siblings' peerDependencies requirements!
error peerinvalid Peer grunt-contrib@0.10.2 wants grunt-contrib-compress@~0.7.0
error System Linux 3.11.0-20-generic
error command "node" "/usr/bin/npm" "update" "-g"
error cwd /home/jeremie
error node -v v0.10.26
error npm -v 1.4.6
error code EPEERINVALID
verbose exit [ 1, true ]
```

```
$ cat /usr/lib/node_modules/grunt-contrib-compress/package.json 
{
  "name": "grunt-contrib-compress",
  "description": "Compress files and folders.",
  "version": "0.8.0",
...
```
